### PR TITLE
Add flags and payload values to facilitate OpenVEX

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -18,6 +18,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"testing"
@@ -268,8 +269,12 @@ func Test_uploadSingleFile(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := uploadSingleFile(tt.args.authenticatedClient, tt.args.defaultClient, tt.args.tenantApiEndpoint, tt.args.filePath, tt.args.uploadMeta); (err != nil) != tt.wantErr {
-				t.Errorf("uploadSingleFile() error = %v, wantErr %v", err, tt.wantErr)
+			for _, isOpenVex := range []bool{false, true} {
+				t.Run(fmt.Sprintf("isOpenVex is %v", isOpenVex), func(t *testing.T) {
+					if err := uploadSingleFile(tt.args.authenticatedClient, tt.args.defaultClient, tt.args.tenantApiEndpoint, tt.args.filePath, isOpenVex, tt.args.uploadMeta); (err != nil) != tt.wantErr {
+						t.Errorf("uploadSingleFile() error = %v, wantErr %v", err, tt.wantErr)
+					}
+				})
 			}
 		})
 	}
@@ -350,8 +355,12 @@ func Test_uploadBlob(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := uploadBlob(tt.args.authenticatedClient, tt.args.presignedUrl, tt.args.filePath, []byte("hello"), tt.args.uploadMeta); (err != nil) != tt.wantErr {
-				t.Errorf("uploadFile() error = %v, wantErr %v", err, tt.wantErr)
+			for _, isOpenVex := range []bool{false, true} {
+				t.Run(fmt.Sprintf("isOpenVex is %v", isOpenVex), func(t *testing.T) {
+					if err := uploadBlob(tt.args.authenticatedClient, tt.args.presignedUrl, tt.args.filePath, []byte("hello"), isOpenVex, tt.args.uploadMeta); (err != nil) != tt.wantErr {
+						t.Errorf("uploadFile() error = %v, wantErr %v", err, tt.wantErr)
+					}
+				})
 			}
 		})
 	}


### PR DESCRIPTION
- Add flag to allow specifying that document is an OpenVEX doc
- Add upload_meta values to identify a VEX document tag and software in   the Kusari Platform